### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/michael-mpj/r3f-batman-workspace/security/code-scanning/8](https://github.com/michael-mpj/r3f-batman-workspace/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow to set the minimal required permissions for all jobs. The recommended default for standard CI workflows is `contents: read`, which allows read-only access to repository contents. Because there is no evidence of jobs that require write or admin access (no deployment or GitHub API calls to mutate anything), the fix consists of adding a `permissions` block at the workflow root, just after the `name:` and before `on:`. Only `.github/workflows/ci.yml` needs editing, and no new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
