### PR TITLE
docs: codify apps vs projects workspace convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ npm run dev
 │   ├── ui/                        # 🎨 UI Components (Button, Panel, ControlGroup)
 │   ├── utils/                     # 🛠️  Utilities (math, geometry, performance, terrain)
 │   └── r3f-components/            # 🌟 Advanced R3F Components
-├── 🚀 projects/                   # Applications
-│   └── R3f-StarterKit/           # Complete R3F demo application
+├── 🚀 projects/                   # Starter templates, sandboxes, and reference demos
+│   └── R3f-StarterKit/           # Canonical starter/reference project
+├── 🌐 apps/                       # Deployable applications and product surfaces
+│   └── cyber-forge/              # Production-style app built on workspace packages
 ├── 🤖 scripts/                    # Batman Automation Arsenal
 │   ├── batman.mjs                # 🦇 Original Batman script
 │   ├── batman-enhanced.mjs       # 🦇🦇 Multi-terminal Batman
@@ -82,6 +84,13 @@ npm run dev
 ├── 🔧 .github/                    # GitHub Actions & Workflows
 └── ⚙️  config files               # ESLint, Prettier, Vite, etc.
 ```
+
+### Folder Convention (Recommended)
+
+- Put **new starter kits, experiments, and reference implementations** in `projects/`.
+- Put **new deployable end-user applications** in `apps/`.
+
+This keeps templates/examples separate from production-facing apps while still supporting both through workspace scripts.
 
 ---
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -11,73 +11,81 @@
 import { defineConfig } from "vitepress";
 
 export default defineConfig({
-  title: "🦇 Batman R3F Workspace",
-  description: "Batman-powered React Three Fiber monorepo with advanced automation and terminal management",
+    title: "🦇 Batman R3F Workspace",
+    description: "Batman-powered React Three Fiber monorepo with advanced automation and terminal management",
 
-  themeConfig: {
-    nav: [
-      { text: "Home", link: "/" },
-      { text: "Guide", link: "/guide/getting-started" },
-      { text: "Packages", link: "/packages/" },
-      { text: "Scripts", link: "/scripts/" },
-      { text: "Projects", link: "/projects/" },
-    ],
+    themeConfig: {
+        nav: [
+            { text: "Home", link: "/" },
+            { text: "Guide", link: "/guide/getting-started" },
+            { text: "Packages", link: "/packages/" },
+            { text: "Scripts", link: "/scripts/" },
+            { text: "Apps", link: "/apps/" },
+            { text: "Projects", link: "/projects/" },
+        ],
 
-    sidebar: {
-      "/guide/": [
-        {
-          text: "Guide",
-          items: [
-            { text: "Getting Started", link: "/guide/getting-started" },
-            { text: "Package Compatibility", link: "/guide/package-compatibility" },
-            { text: "Development Workflow", link: "/guide/development-workflow" },
-            { text: "Deployment", link: "/guide/deployment" },
-          ],
+        sidebar: {
+            "/guide/": [
+                {
+                    text: "Guide",
+                    items: [
+                        { text: "Getting Started", link: "/guide/getting-started" },
+                        { text: "Package Compatibility", link: "/guide/package-compatibility" },
+                        { text: "Development Workflow", link: "/guide/development-workflow" },
+                        { text: "Deployment", link: "/guide/deployment" },
+                        { text: "Workspace Conventions", link: "/guide/workspace-conventions" },
+                    ],
+                },
+            ],
+            "/apps/": [
+                {
+                    text: "Apps",
+                    items: [{ text: "Overview", link: "/apps/" }],
+                },
+            ],
+            "/packages/": [
+                {
+                    text: "Packages",
+                    items: [
+                        { text: "Overview", link: "/packages/" },
+                        { text: "UI Components", link: "/packages/ui" },
+                        { text: "Utilities", link: "/packages/utils" },
+                    ],
+                },
+            ],
+            "/scripts/": [
+                {
+                    text: "Scripts",
+                    items: [
+                        { text: "Overview", link: "/scripts/" },
+                        { text: "Compatibility Check", link: "/scripts/compatibility" },
+                        { text: "Build Scripts", link: "/scripts/build" },
+                        { text: "Development Scripts", link: "/scripts/dev" },
+                    ],
+                },
+            ],
+            "/projects/": [
+                {
+                    text: "Projects",
+                    items: [
+                        { text: "Overview", link: "/projects/" },
+                        { text: "R3F StarterKit", link: "/projects/r3f-starterkit" },
+                    ],
+                },
+            ],
         },
-      ],
-      "/packages/": [
-        {
-          text: "Packages",
-          items: [
-            { text: "Overview", link: "/packages/" },
-            { text: "UI Components", link: "/packages/ui" },
-            { text: "Utilities", link: "/packages/utils" },
-          ],
+
+        socialLinks: [{ icon: "github", link: "https://github.com/michael-mpj/r3f-batman-workspace" }],
+
+        footer: {
+            message: "Released under the MIT License.",
+            copyright: "Copyright © 2025 Batman R3F Workspace",
         },
-      ],
-      "/scripts/": [
-        {
-          text: "Scripts",
-          items: [
-            { text: "Overview", link: "/scripts/" },
-            { text: "Compatibility Check", link: "/scripts/compatibility" },
-            { text: "Build Scripts", link: "/scripts/build" },
-            { text: "Development Scripts", link: "/scripts/dev" },
-          ],
-        },
-      ],
-      "/projects/": [
-        {
-          text: "Projects",
-          items: [
-            { text: "Overview", link: "/projects/" },
-            { text: "R3F StarterKit", link: "/projects/r3f-starterkit" },
-          ],
-        },
-      ],
     },
 
-    socialLinks: [{ icon: "github", link: "https://github.com/michael-mpj/r3f-batman-workspace" }],
-
-    footer: {
-      message: "Released under the MIT License.",
-      copyright: "Copyright © 2025 Batman R3F Workspace",
+    vite: {
+        server: {
+            port: 5173,
+        },
     },
-  },
-
-  vite: {
-    server: {
-      port: 5173,
-    },
-  },
 });

--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -1,0 +1,63 @@
+# Apps Overview
+
+This section covers **deployable applications** in the Batman R3F Workspace.
+
+## 🌐 Current Apps
+
+### cyber-forge
+
+`apps/cyber-forge` is a deployable app surface built on workspace packages and shared tooling.
+
+## 📌 Folder Convention
+
+Use this decision rule:
+
+- Put starter kits, references, and experiments in `projects/`
+- Put deployable user-facing applications in `apps/`
+
+This keeps development templates separate from production-oriented app surfaces.
+
+## 🛠️ Creating a New App
+
+1. **Create app directory:**
+
+   ```bash
+   mkdir apps/my-new-app
+   cd apps/my-new-app
+   ```
+
+2. **Initialize app package:**
+
+   ```bash
+   npm init -y
+   ```
+
+3. **Use workspace packages:**
+
+   ```json
+   {
+     "name": "my-new-app",
+     "private": true,
+     "type": "module",
+     "scripts": {
+       "dev": "vite",
+       "build": "vite build",
+       "preview": "vite preview"
+     },
+     "dependencies": {
+       "@r3f-workspace/ui": "workspace:*",
+       "@r3f-workspace/utils": "workspace:*",
+       "@r3f-workspace/r3f-components": "workspace:*"
+     }
+   }
+   ```
+
+4. **Run app locally:**
+
+   ```bash
+   npm run dev --workspace=apps/my-new-app
+   ```
+
+## 🚀 Deployment
+
+Apps are expected to be deployable with the same shared workspace conventions used by existing app scripts.

--- a/docs/guide/workspace-conventions.md
+++ b/docs/guide/workspace-conventions.md
@@ -1,0 +1,33 @@
+# Workspace Conventions
+
+This document defines how to place new workspaces and keep the monorepo predictable.
+
+## Folder Roles
+
+- `packages/`: reusable shared libraries used by apps/projects
+- `projects/`: starter kits, demos, references, and exploratory work
+- `apps/`: deployable end-user applications
+
+## Placement Rule
+
+When creating `newproject1` / `newproject2`, decide by intent:
+
+- If it's a starter/template/reference → `projects/<name>`
+- If it's a deployable app surface → `apps/<name>`
+
+## Naming Guidance
+
+- Use `kebab-case` for folder names
+- Keep package `name` aligned with folder intent
+- Prefer clear names that reflect purpose (`starterkit`, `dashboard-app`, `demo-physics`)
+
+## Script Compatibility
+
+Both `apps/*` and `projects/*` are included in workspace scripts. Keep each workspace providing at least:
+
+- `dev`
+- `build`
+- `test` (if applicable)
+- `lint`
+
+This ensures root-level commands continue to work consistently.

--- a/docs/guide/workspace-conventions.md
+++ b/docs/guide/workspace-conventions.md
@@ -31,3 +31,21 @@ Both `apps/*` and `projects/*` are included in workspace scripts. Keep each work
 - `lint`
 
 This ensures root-level commands continue to work consistently.
+
+## Create Workspace Helper
+
+Use the scaffold helper to create new workspaces with consistent defaults:
+
+```bash
+# New deployable app
+npm run workspace:create -- --type app --name newproject1
+
+# New starter/reference project
+npm run workspace:create -- --type project --name newproject2
+```
+
+Optional:
+
+```bash
+npm run workspace:create -- --type app --name dashboard-app --port 3010
+```

--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -1,6 +1,11 @@
 # Projects Overview
 
-This section covers the applications and demo projects in the Batman R3F Workspace.
+This section covers **starter/reference projects** in the Batman R3F Workspace.
+
+> 📌 **Convention:**
+>
+> - Use `projects/` for starter kits, sandboxes, and reference implementations.
+> - Use `apps/` for deployable user-facing applications.
 
 ## 🚀 Available Projects
 
@@ -21,6 +26,8 @@ A comprehensive demonstration application showcasing all workspace capabilities.
 ## 🛠️ Project Development
 
 ### Creating New Projects
+
+Use this flow when creating a new **starter/reference** project.
 
 1. **Create project directory:**
 
@@ -58,6 +65,8 @@ A comprehensive demonstration application showcasing all workspace capabilities.
 4. **Add to workspace:**
 
    The project will automatically be included in the workspace workspaces configuration.
+
+If the target is a deployable app, create it under `apps/` instead (see `/apps/` docs).
 
 ### Project Structure
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint:fix": "npm run lint:fix --workspaces --if-present",
     "format": "prettier --write .",
     "check-compatibility": "node scripts/check-compatibility.mjs",
+    "workspace:create": "node scripts/create-workspace.mjs",
     "batman": "node scripts/batman.mjs",
     "batman:enhanced": "node scripts/batman-enhanced.mjs",
     "batman:vscode": "node scripts/batman-vscode.mjs",

--- a/packages/r3f-components/config/landing-fallback.json
+++ b/packages/r3f-components/config/landing-fallback.json
@@ -175,6 +175,22 @@
             ]
         }
     ],
+    "featuredWorkspaces": [
+        {
+            "key": "starterkit",
+            "title": "R3f-StarterKit",
+            "type": "project",
+            "path": "projects/R3f-StarterKit",
+            "description": "Canonical starter/reference project for workspace patterns."
+        },
+        {
+            "key": "cyber-forge",
+            "title": "cyber-forge",
+            "type": "app",
+            "path": "apps/cyber-forge",
+            "description": "Deployable app surface built on shared workspace packages."
+        }
+    ],
     "toolSnapshot": {
         "node": "^24.0.0",
         "npm": ">=10.9.3",

--- a/packages/r3f-components/public/index.html
+++ b/packages/r3f-components/public/index.html
@@ -213,6 +213,24 @@
 
   <section>
     <div class="container">
+      <h2 class="section-title">Featured workspaces</h2>
+      <div class="grid cols-2" id="featured-workspaces-grid">
+        <article class="card">
+          <h3>🚀 R3f-StarterKit</h3>
+          <p class="muted">Canonical starter/reference project for workspace patterns.</p>
+          <p><code>projects/R3f-StarterKit</code></p>
+        </article>
+        <article class="card">
+          <h3>🕶️ cyber-forge</h3>
+          <p class="muted">Deployable app surface built on shared workspace packages.</p>
+          <p><code>apps/cyber-forge</code></p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="container">
       <h2 class="section-title">Core developer workflow</h2>
       <div class="grid cols-4">
         <article class="card">
@@ -317,6 +335,16 @@
         setList("projects-list", data.architecture?.projects, item => `<li><code>${escapeHtml(item.path || item.name)}</code></li>`);
 
         setList("apps-list", data.architecture?.apps, item => `<li><code>${escapeHtml(item.path || item.name)}</code></li>`);
+
+        const featuredGrid = document.getElementById("featured-workspaces-grid");
+        if (featuredGrid && Array.isArray(data.featuredWorkspaces) && data.featuredWorkspaces.length > 0) {
+          featuredGrid.innerHTML = data.featuredWorkspaces
+            .map(item => {
+              const icon = item.type === "project" ? "🚀" : "🕶️";
+              return `<article class="card"><h3>${icon} ${escapeHtml(item.title || item.path)}</h3><p class="muted">${escapeHtml(item.description || "")}</p><p><code>${escapeHtml(item.path || "")}</code></p></article>`;
+            })
+            .join("");
+        }
 
         const workflowGroups = Array.isArray(data.workflowGroups) ? data.workflowGroups : [];
         const groupToListId = {

--- a/packages/r3f-components/scripts/generate-landing-data.mjs
+++ b/packages/r3f-components/scripts/generate-landing-data.mjs
@@ -114,6 +114,35 @@ function pickWorkflowGroups(scripts = {}) {
     .filter(group => group.items.length > 0);
 }
 
+function pickFeaturedWorkspaces({ projects = [], apps = [] }) {
+  const starterKit = projects.find(item => item.path === "projects/R3f-StarterKit") || projects[0];
+  const cyberForge = apps.find(item => item.path === "apps/cyber-forge") || apps[0];
+
+  const featured = [];
+
+  if (starterKit) {
+    featured.push({
+      key: "starterkit",
+      title: "R3f-StarterKit",
+      type: "project",
+      path: starterKit.path,
+      description: starterKit.description || "Canonical starter/reference project for workspace patterns.",
+    });
+  }
+
+  if (cyberForge) {
+    featured.push({
+      key: "cyber-forge",
+      title: "cyber-forge",
+      type: "app",
+      path: cyberForge.path,
+      description: cyberForge.description || "Deployable app surface built on shared workspace packages.",
+    });
+  }
+
+  return featured;
+}
+
 async function main() {
   const fallback = (await readJsonIfExists(fallbackFile)) || {};
   const rootPkg = (await readJsonIfExists(path.join(workspaceRoot, "package.json"))) || {};
@@ -128,6 +157,10 @@ async function main() {
   const hasDiscoveredWorkspace = packages.length > 0 || projects.length > 0 || apps.length > 0;
   const scripts = pickScripts(rootPkg.scripts);
   const workflowGroups = pickWorkflowGroups(rootPkg.scripts);
+  const featuredWorkspaces = pickFeaturedWorkspaces({
+    projects: hasDiscoveredWorkspace ? projects : fallback.architecture?.projects || [],
+    apps: hasDiscoveredWorkspace ? apps : fallback.architecture?.apps || [],
+  });
 
   const data = {
     generatedAt: new Date().toISOString(),
@@ -158,6 +191,7 @@ async function main() {
     },
     scripts: scripts.length > 0 ? scripts : fallback.scripts || [],
     workflowGroups: workflowGroups.length > 0 ? workflowGroups : fallback.workflowGroups || [],
+    featuredWorkspaces: featuredWorkspaces.length > 0 ? featuredWorkspaces : fallback.featuredWorkspaces || [],
     toolSnapshot: {
       node: rootPkg.engines?.node || fallback.toolSnapshot?.node || "not specified",
       npm: rootPkg.engines?.npm || fallback.toolSnapshot?.npm || "not specified",

--- a/scripts/create-workspace.mjs
+++ b/scripts/create-workspace.mjs
@@ -8,7 +8,9 @@ const __dirname = path.dirname(__filename);
 const workspaceRoot = path.resolve(__dirname, "..");
 
 function printUsage() {
-    process.stdout.write(`\nUsage:\n  npm run workspace:create -- --type <app|project> --name <workspace-name> [--port <number>]\n\nExamples:\n  npm run workspace:create -- --type app --name newproject1\n  npm run workspace:create -- --type project --name physics-lab --port 3010\n\n`);
+    process.stdout.write(
+        `\nUsage:\n  npm run workspace:create -- --type <app|project> --name <workspace-name> [--port <number>]\n\nExamples:\n  npm run workspace:create -- --type app --name newproject1\n  npm run workspace:create -- --type project --name physics-lab --port 3010\n\n`
+    );
 }
 
 function parseArgs(argv) {
@@ -60,9 +62,9 @@ function buildPackageJson({ name, type }) {
                 lint: "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
             },
             dependencies: {
-                react: "^19.0.0",
+                "react": "^19.0.0",
                 "react-dom": "^19.0.0",
-                three: "^0.180.0",
+                "three": "^0.180.0",
                 "@react-three/fiber": "^9.3.0",
                 "@react-three/drei": "^10.7.4",
                 "@r3f-workspace/ui": "file:../../packages/ui",
@@ -70,13 +72,13 @@ function buildPackageJson({ name, type }) {
                 "@r3f-workspace/r3f-components": "file:../../packages/r3f-components",
             },
             devDependencies: {
-                vite: "^8.0.14",
+                "vite": "^8.0.14",
                 "@vitejs/plugin-react": "^5.0.2",
-                eslint: "^10.4.0",
+                "eslint": "^10.4.0",
             },
         },
         null,
-        2,
+        2
     )}\n`;
 }
 
@@ -110,20 +112,20 @@ async function main() {
     await createIfMissing(path.join(targetDir, "package.json"), buildPackageJson({ name: args.name, type: args.type }));
     await createIfMissing(
         path.join(targetDir, "index.html"),
-        `<!doctype html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n    <title>${args.name}</title>\n  </head>\n  <body>\n    <div id="root"></div>\n    <script type="module" src="/src/main.jsx"></script>\n  </body>\n</html>\n`,
+        `<!doctype html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n    <title>${args.name}</title>\n  </head>\n  <body>\n    <div id="root"></div>\n    <script type="module" src="/src/main.jsx"></script>\n  </body>\n</html>\n`
     );
     await createIfMissing(path.join(targetDir, "vite.config.js"), buildViteConfig(Number.isNaN(targetPort) ? 3005 : targetPort));
     await createIfMissing(
         path.join(targetDir, "src", "main.jsx"),
-        `import React from "react";\nimport ReactDOM from "react-dom/client";\nimport App from "./App";\n\nReactDOM.createRoot(document.getElementById("root")).render(\n  <React.StrictMode>\n    <App />\n  </React.StrictMode>,\n);\n`,
+        `import React from "react";\nimport ReactDOM from "react-dom/client";\nimport App from "./App";\n\nReactDOM.createRoot(document.getElementById("root")).render(\n  <React.StrictMode>\n    <App />\n  </React.StrictMode>,\n);\n`
     );
     await createIfMissing(
         path.join(targetDir, "src", "App.jsx"),
-        `export default function App() {\n  return (\n    <main style={{ fontFamily: "Inter, system-ui", padding: "2rem" }}>\n      <h1>${args.name}</h1>\n      <p>Workspace scaffold created by r3f-batman <code>workspace:create</code>.</p>\n    </main>\n  );\n}\n`,
+        `export default function App() {\n  return (\n    <main style={{ fontFamily: "Inter, system-ui", padding: "2rem" }}>\n      <h1>${args.name}</h1>\n      <p>Workspace scaffold created by r3f-batman <code>workspace:create</code>.</p>\n    </main>\n  );\n}\n`
     );
     await createIfMissing(
         path.join(targetDir, "README.md"),
-        `# ${args.name}\n\nScaffolded as a ${args.type} workspace using \`npm run workspace:create\`.\n\n## Run\n\n\`\`\`bash\nnpm run dev --workspace=${targetRoot}/${args.name}\n\`\`\`\n`,
+        `# ${args.name}\n\nScaffolded as a ${args.type} workspace using \`npm run workspace:create\`.\n\n## Run\n\n\`\`\`bash\nnpm run dev --workspace=${targetRoot}/${args.name}\n\`\`\`\n`
     );
 
     process.stdout.write(`✅ Created ${args.type} workspace at ${targetRoot}/${args.name}\n`);

--- a/scripts/create-workspace.mjs
+++ b/scripts/create-workspace.mjs
@@ -1,0 +1,136 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const workspaceRoot = path.resolve(__dirname, "..");
+
+function printUsage() {
+    process.stdout.write(`\nUsage:\n  npm run workspace:create -- --type <app|project> --name <workspace-name> [--port <number>]\n\nExamples:\n  npm run workspace:create -- --type app --name newproject1\n  npm run workspace:create -- --type project --name physics-lab --port 3010\n\n`);
+}
+
+function parseArgs(argv) {
+    const args = { type: "", name: "", port: "" };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === "--type") args.type = argv[index + 1] || "";
+        if (arg === "--name") args.name = argv[index + 1] || "";
+        if (arg === "--port") args.port = argv[index + 1] || "";
+    }
+
+    return args;
+}
+
+function validateName(name) {
+    return /^[a-z0-9][a-z0-9-]*$/.test(name);
+}
+
+async function ensureDirectory(targetDir) {
+    await fs.mkdir(targetDir, { recursive: true });
+}
+
+async function createIfMissing(filePath, content) {
+    try {
+        await fs.access(filePath);
+        throw new Error(`File already exists: ${filePath}`);
+    } catch (error) {
+        if (error.code !== "ENOENT") {
+            throw error;
+        }
+        await fs.writeFile(filePath, content, "utf8");
+    }
+}
+
+function buildPackageJson({ name, type }) {
+    const packageName = type === "app" ? name : `r3f-${name}`;
+
+    return `${JSON.stringify(
+        {
+            name: packageName,
+            private: true,
+            version: "0.0.0",
+            type: "module",
+            scripts: {
+                dev: "vite",
+                build: "vite build",
+                preview: "vite preview",
+                lint: "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+            },
+            dependencies: {
+                react: "^19.0.0",
+                "react-dom": "^19.0.0",
+                three: "^0.180.0",
+                "@react-three/fiber": "^9.3.0",
+                "@react-three/drei": "^10.7.4",
+                "@r3f-workspace/ui": "file:../../packages/ui",
+                "@r3f-workspace/utils": "file:../../packages/utils",
+                "@r3f-workspace/r3f-components": "file:../../packages/r3f-components",
+            },
+            devDependencies: {
+                vite: "^8.0.14",
+                "@vitejs/plugin-react": "^5.0.2",
+                eslint: "^10.4.0",
+            },
+        },
+        null,
+        2,
+    )}\n`;
+}
+
+function buildViteConfig(port) {
+    return `import { defineConfig } from "vite";\nimport react from "@vitejs/plugin-react";\n\nexport default defineConfig({\n  plugins: [react()],\n  server: {\n    port: ${port},\n    host: true,\n  },\n});\n`;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (!args.type || !args.name) {
+        printUsage();
+        throw new Error("Missing required arguments: --type and --name");
+    }
+
+    if (!["app", "project"].includes(args.type)) {
+        printUsage();
+        throw new Error("Invalid --type. Use 'app' or 'project'.");
+    }
+
+    if (!validateName(args.name)) {
+        throw new Error("Invalid --name. Use kebab-case (lowercase letters, numbers, hyphens).");
+    }
+
+    const targetRoot = args.type === "app" ? "apps" : "projects";
+    const targetDir = path.join(workspaceRoot, targetRoot, args.name);
+    const targetPort = Number.parseInt(args.port || "3005", 10);
+
+    await ensureDirectory(path.join(targetDir, "src"));
+
+    await createIfMissing(path.join(targetDir, "package.json"), buildPackageJson({ name: args.name, type: args.type }));
+    await createIfMissing(
+        path.join(targetDir, "index.html"),
+        `<!doctype html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n    <title>${args.name}</title>\n  </head>\n  <body>\n    <div id="root"></div>\n    <script type="module" src="/src/main.jsx"></script>\n  </body>\n</html>\n`,
+    );
+    await createIfMissing(path.join(targetDir, "vite.config.js"), buildViteConfig(Number.isNaN(targetPort) ? 3005 : targetPort));
+    await createIfMissing(
+        path.join(targetDir, "src", "main.jsx"),
+        `import React from "react";\nimport ReactDOM from "react-dom/client";\nimport App from "./App";\n\nReactDOM.createRoot(document.getElementById("root")).render(\n  <React.StrictMode>\n    <App />\n  </React.StrictMode>,\n);\n`,
+    );
+    await createIfMissing(
+        path.join(targetDir, "src", "App.jsx"),
+        `export default function App() {\n  return (\n    <main style={{ fontFamily: "Inter, system-ui", padding: "2rem" }}>\n      <h1>${args.name}</h1>\n      <p>Workspace scaffold created by r3f-batman <code>workspace:create</code>.</p>\n    </main>\n  );\n}\n`,
+    );
+    await createIfMissing(
+        path.join(targetDir, "README.md"),
+        `# ${args.name}\n\nScaffolded as a ${args.type} workspace using \`npm run workspace:create\`.\n\n## Run\n\n\`\`\`bash\nnpm run dev --workspace=${targetRoot}/${args.name}\n\`\`\`\n`,
+    );
+
+    process.stdout.write(`✅ Created ${args.type} workspace at ${targetRoot}/${args.name}\n`);
+    process.stdout.write(`Next: npm install && npm run dev --workspace=${targetRoot}/${args.name}\n`);
+}
+
+main().catch(error => {
+    process.stderr.write(`❌ ${error.message}\n`);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
This PR introduces a clear, no-behavior-change workspace placement convention to reduce ambiguity when creating new workspaces.

## Decision
Keep both folders and use intent-based placement:
- `projects/` → starter kits, demos, references, experiments
- `apps/` → deployable user-facing applications

## Changes
- Updated root `README.md` architecture section to include both `projects/` and `apps` roles.
- Updated `docs/projects/index.md` to explicitly position projects as starter/reference work.
- Added `docs/apps/index.md` for deployable app guidance.
- Added `docs/guide/workspace-conventions.md` with the decision rule and naming guidance.
- Updated VitePress nav/sidebar in `docs/.vitepress/config.js` to expose Apps docs and Workspace Conventions.

## Why
Current repository usage already supports both:
- `projects/R3f-StarterKit` as a canonical starter/reference workspace
- `apps/cyber-forge` as a deployable app surface

This PR aligns docs with existing scripts and package/workspace behavior while avoiding disruptive folder migrations.

## Scope
- Docs and navigation only
- No runtime code or CI behavior changes
